### PR TITLE
Add minimum to thread count

### DIFF
--- a/html/mydumper_usage.html
+++ b/html/mydumper_usage.html
@@ -930,7 +930,7 @@
 <dl class="std option">
 <dt class="sig sig-object std" id="cmdoption-mydumper-t">
 <span id="cmdoption-mydumper-threads"></span><span class="sig-name descname"><span class="pre">-t</span></span><span class="sig-prename descclassname"></span><span class="sig-prename descclassname"><span class="pre">,</span> </span><span class="sig-name descname"><span class="pre">--threads</span></span><span class="sig-prename descclassname"></span><a class="headerlink" href="#cmdoption-mydumper-t" title="Permalink to this definition">¶</a></dt>
-<dd><p>Number of threads to use, 0 means to use number of CPUs. Default: 4</p>
+<dd><p>Number of threads to use, 0 means to use number of CPUs. Default: 4, Minimum: 2</p>
 </dd></dl>
 
 <dl class="std option">


### PR DESCRIPTION
I tried to set max_threads to 1 because mydumper dumping too fast.
Until I enabled debug logging I did not see that mydumper is still using 2 threads.

Based on https://github.com/mydumper/mydumper/blob/5dae2cdf51de0ed84754e68f9cb6010b71916948/src/common.c#L770